### PR TITLE
Add separate section with troubleshooting tips.

### DIFF
--- a/config.toml
+++ b/config.toml
@@ -19,7 +19,13 @@ publishdir = "public"
   name   = "Api"
   url    = "/api"
   weight = 20
+
 [[menu.main]]
   name   = "Information models"
   url    = "/models"
   weight = 40
+
+[[menu.main]]
+  name   = "Troubleshooting"
+  url    = "/troubleshooting"
+  weight = 50

--- a/content/troubleshooting/basic.md
+++ b/content/troubleshooting/basic.md
@@ -1,0 +1,7 @@
++++
+title = "Basic troubleshooting"
+description = "Why isn't it working?  Tips for getting unstuck."
+weight = 1
++++
+
+# 

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -11,6 +11,7 @@
             <p class="fint-highlights">
                 <a href="/adapter" class="btn btn-lg btn-default active" role="button">I want to develop adapter <i class="fa fa-plug" aria-hidden="true"></i></a>
                 <a href="/api" class="btn btn-lg btn-default active" role="button">I want to use the FINT APIs <i class="fa fa-cloud" aria-hidden="true"></i></a>
+                <a href="/troubleshooting" class="btn btn-lg btn-default active" role="button">Troubleshooting <i class="fa fa-exclamation-triangle" aria-hidden="true"></i></a>
                 <a href="https://play-with-fint.felleskomponent.no/administrasjon/personal/personalressurs" target="_blank" class="btn btn-lg btn-default active" role="button">Play-With-FINT <i class="fa fa-play" aria-hidden="true"></i></a>
             </p>
 

--- a/layouts/troubleshooting/list.html
+++ b/layouts/troubleshooting/list.html
@@ -1,0 +1,44 @@
+{{ partial "header.html" . }}
+
+<div class="row">
+    <div class="col-sm-12 doc-main">
+        <main role="main">
+            <div class="doc-list-header">
+                <h3>{{ .Title }}</h3>
+            </div>
+            <div class="doc-list-entry">
+                <div class="panel panel-default">
+                    <div class="panel-body">
+                        <table class="table table-hover">
+                            <thead>
+                                <tr>
+                                    <th>Document</th>
+                                    <th>Description</th>
+                                </tr>
+                            </thead>
+                            {{ range .Data.Pages }}
+                            <tr>
+                                <td>
+                                    <a class="doc-entry" href="{{ .RelPermalink }}">
+                                        <span class="doc-entry-title">{{ .Title }}{{ if .Draft }} #Draft{{ end }}</span>
+
+                                    </a>
+                                </td>
+                                <td>
+                                    {{ .Params.description }}
+                                </td>
+                            </tr>
+                            {{ end }}
+                        </table>
+                    </div>
+                </div>
+        </main>
+        </div>
+        <!-- /.doc-main -->
+
+
+
+    </div>
+    <!-- /.row -->
+
+    {{ partial "footer.html" . }}


### PR DESCRIPTION
Should we have a separate section with troubleshooting tips?  Or pages within the /api and /adapter sections?